### PR TITLE
Patch nov 2024

### DIFF
--- a/eks-terraform/README.md
+++ b/eks-terraform/README.md
@@ -22,7 +22,7 @@ Give it a review but this should create all assets required including a vpc and 
 1. Create a new namespace for harness `kubectl create ns harness`
 2. Next, create a loadbalancer and default backend using our "known-good" reference: `kubectl create -f eks-terraform/loadbalancer.yaml -n harness`
 3. Retrieve the resulting address from `kubectl get svc -n harness` it will look like an ALB address such as `a03c7375880b84b5099d042fd72b316c-952477994.us-gov-west-1.elb.amazonaws.com` but with a different identifier. 
-4. Modify the following values within `src/harness/values.yaml`. See [SSL Guidance](#ssl) if you would like to configure SSL certificate at this point.
+4. Modify the following values within `src/harness/values.yaml`. See SSL Guidance docs below if you would like to configure SSL certificate at this point.
 ```
 global:
 ...
@@ -40,7 +40,7 @@ global:
     cg: '' # leave blank
     ng: '' # if you have a license, put that string within the quotes here
 ```
-5. After this is completed, we can apply our helm installation. Our recommendation is to utilize the `override-demo.yaml` for the resource definitions at least initially but there are other options for sizing that we can move to if needed to shrink or grow our utilization (https://developer.harness.io/docs/self-managed-enterprise-edition/reference-architecture/). The following will install our latest version of Harness SMP but we can specify a `--version` if we wish as well.
+1. After this is completed, we can apply our helm installation. Our recommendation is to utilize the `override-demo.yaml` for the resource definitions at least initially but there are other options for sizing that we can move to if needed to shrink or grow our utilization (https://developer.harness.io/docs/self-managed-enterprise-edition/reference-architecture/). The following will install our latest version of Harness SMP but we can specify a `--version` if we wish as well.
 ```
 # Retrieve helm repos
 helm repo add harness https://harness.github.io/helm-charts
@@ -78,7 +78,7 @@ NOTES:
 8. If you're provided a license later or want to make modifications to your URL/add TLS then we can run a `helm upgrade` on this release with the new values applied.
 
 
-### SSL/TLS via Self-Signed Certificates {#ssl}
+### SSL/TLS via Self-Signed Certificates
 One option to keep things simple is to use a self-signed certificate in place of certificates provided by your Certificate Authority tied to your DNS intended to act as the front-end of your Harness platform. These can done during initial setup or modified later once you're ready to move to production.
 
 Generate a self-signed certificate and private key using `openssl` (this [guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/) is helpful).

--- a/eks-terraform/loadbalancer.yaml
+++ b/eks-terraform/loadbalancer.yaml
@@ -80,7 +80,10 @@ metadata:
   name: harness-ingress-controller
   namespace: harness
   labels: {}
-  annotations: {}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "alb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing" # Or "internal" for internal access
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
 spec:
   selector:
     app: harness-ingress-controller

--- a/eks-terraform/main.tf
+++ b/eks-terraform/main.tf
@@ -86,9 +86,9 @@ module "eks" {
 }
 
 # https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/ 
-# Ensure this points to the GovCloud variant if you're using that
+# Checks if this is a govcloud deployment, ensures the correct IAM policy is applied for EBS CSI driver functionality
 data "aws_iam_policy" "ebs_csi_policy" {
-  arn = "arn:aws-us-gov:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  arn = contains(["us-gov-west-1", "us-gov-east-1"], var.region) ? "arn:aws-us-gov:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy" : "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 }
 
 module "irsa-ebs-csi" {

--- a/eks-terraform/variables.tf
+++ b/eks-terraform/variables.tf
@@ -4,7 +4,7 @@
 variable "region" {
   description = "AWS region"
   type        = string
-  default     = "us-gov-west-1"
+  default     = "us-east-1"
 }
 
 variable "eks_cluster_version" {


### PR DESCRIPTION
This pull request includes updates to the `eks-terraform/README.md` file to improve clarity and add instructions for SSL/TLS configuration, as well as changes to other files to enhance compatibility and functionality. The most important changes include updates to the README for better guidance, modifications to the load balancer configuration, and improvements to the Terraform scripts for region-specific settings.

Updates to README for better guidance:

* [`eks-terraform/README.md`](diffhunk://#diff-c3b413c6705a4b560bf2cda51343d483027c06a5e988800aad80640294265039L3-R39): Clarified instructions for setting up EKS clusters, added tools like `kubectl`, `helm`, and `openssl`, and provided detailed steps for SSL/TLS configuration using self-signed certificates. [[1]](diffhunk://#diff-c3b413c6705a4b560bf2cda51343d483027c06a5e988800aad80640294265039L3-R39) [[2]](diffhunk://#diff-c3b413c6705a4b560bf2cda51343d483027c06a5e988800aad80640294265039R50) [[3]](diffhunk://#diff-c3b413c6705a4b560bf2cda51343d483027c06a5e988800aad80640294265039R84-R160)

Load balancer configuration:

* [`eks-terraform/loadbalancer.yaml`](diffhunk://#diff-741b48667fd6a67fde2fd06560e45ba174746c6f487a205b3671240d7ea54998L83-R86): Added annotations for AWS load balancer type, scheme, and SSL ports to ensure correct setup and functionality.

Terraform script improvements:

* [`eks-terraform/main.tf`](diffhunk://#diff-b3733968a4aa2115e7f8e520fa7d85c28a3496a36b57f95884428357b509a457L89-R91): Updated IAM policy selection logic to ensure the correct policy is applied based on the region, supporting both commercial and GovCloud deployments.
* [`eks-terraform/variables.tf`](diffhunk://#diff-b8ab67463fffdcfb3c7a6c55f83bf4d05a972f8809300d784178c6d4bb868cf3L7-R7): Changed the default AWS region from `us-gov-west-1` to `us-east-1` to align with broader usage.